### PR TITLE
switching from java  serialization to kryo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ P4 --------->  |               |  |                +--------------->  |
 ### how-to
 
 ```
-"net.globalwebindex" %% "saturator" % "0.02-SNAPSHOT"
+"net.globalwebindex" %% "saturator" % "0.04-SNAPSHOT"
 ```
 
 See demo at `example/`. Akka persistence uses redis plugin as it is the best fit for saturator unless DAG gets really complex or
 it has a lot of partitions in which case something like Cassandra would be a better fit.
+It uses Kryo serialization because event log is persisted only temporarily and it would be deleted on new deploy.
 
 ```
 $ cd docker

--- a/core/src/main/resources/serialization.conf
+++ b/core/src/main/resources/serialization.conf
@@ -1,0 +1,17 @@
+akka {
+
+  actor {
+    serializers {
+      java = "akka.serialization.JavaSerializer"
+      kryo = "com.romix.akka.serialization.kryo.KryoSerializer"
+    }
+    serialization-bindings {
+      "java.io.Serializable" = none
+      "gwi.saturator.DagState$DagStateEvent" = kryo
+    }
+    kryo  {
+      idstrategy = "automatic"
+    }
+  }
+}
+

--- a/example/src/main/scala/gwi/saturator/Launcher.scala
+++ b/example/src/main/scala/gwi/saturator/Launcher.scala
@@ -1,7 +1,7 @@
 package gwi.saturator
 
 import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
-import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.ConfigValueFactory
 import gwi.saturator.DagFSM.{CreatePartition, Saturate, SaturationResponse}
 import org.backuity.clist._
 import org.backuity.clist.util.Read
@@ -22,7 +22,7 @@ object Launcher extends CliMain[Unit] {
   var newPartitionInterval = arg[Int](name = "new-partition-interval")
 
   override def run: Unit = {
-    val system = ActorSystem("example", ConfigFactory.parseString(DagFSMSpec.config).withValue("redis.host", ConfigValueFactory.fromAnyRef("redis")))
+    val system = ActorSystem("example", DagFSMSpec.config.withValue("redis.host", ConfigValueFactory.fromAnyRef("redis")))
 
     val vertices = edges.flatMap(t => Set(t._1, t._2)).toSet
     val headVertex = edges.head._1

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,6 +8,8 @@ import sbtdocker.mutable.Dockerfile
 
 object Build extends sbt.Build {
 
+  lazy val appVersion = "0.04-SNAPSHOT"
+
   lazy val akkaVersion = "2.4.11"
 
   lazy val testSettings = Seq(
@@ -20,6 +22,7 @@ object Build extends sbt.Build {
     "com.lihaoyi"                 %%  "pprint"                                % "0.4.1",
     "com.typesafe.scala-logging"  %%  "scala-logging"                         % "3.4.0",
     "com.hootsuite"               %%  "akka-persistence-redis"                % "0.6.0",
+    "com.github.romix.akka"       %%  "akka-kryo-serialization"               % "0.5.0",
     "com.typesafe.akka"           %%  "akka-remote"                           % akkaVersion,
     "com.typesafe.akka"           %%  "akka-cluster"                          % akkaVersion,
     "com.typesafe.akka"           %%  "akka-cluster-tools"                    % akkaVersion,
@@ -31,7 +34,7 @@ object Build extends sbt.Build {
 
   lazy val sharedSettings = Seq(
     organization := "net.globalwebindex",
-    version := "0.02-SNAPSHOT",
+    version := appVersion,
     scalaVersion := "2.11.8",
     offline := true,
     assembleArtifact := false,


### PR DESCRIPTION
Java serialization is very slow and the output is ~ 300-400% times bigger than of Kryo.
It wouldn't be possible to use Redis if it wasn't for Kryo, something like Cassandra/Scylla would have to be used for event log persistence.