### PR TITLE
V2 experimental

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 
-version in ThisBuild := "0.0.4"
-crossScalaVersions in ThisBuild := Seq("2.12.1", "2.11.8")
+version in ThisBuild := "0.0.5"
+crossScalaVersions in ThisBuild := Seq("2.12.3", "2.11.8")
 organization in ThisBuild := "net.globalwebindex"
 fork in Test in ThisBuild := true
 libraryDependencies in ThisBuild ++= loggingApi ++ Seq(akkaActor, akkaTestkit, akkaPersistence, akkaPersistenceRedis, akkaKryoSerialization, scalatest)

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -7,7 +7,7 @@ akka {
     }
     serialization-bindings {
       "gwi.saturator.DagState$StateInitializedEvent" = kryo
-      "gwi.saturator.DagState$SaturationInitializedEvent" = kryo
+      "gwi.saturator.DagState$SaturationInitializedEvent$" = kryo
       "gwi.saturator.DagState$SaturationSucceededEvent" = kryo
       "gwi.saturator.DagState$SaturationFailedEvent" = kryo
       "gwi.saturator.DagState$PartitionCreatedEvent" = kryo

--- a/core/src/main/scala/gwi/saturator/Dag.scala
+++ b/core/src/main/scala/gwi/saturator/Dag.scala
@@ -1,6 +1,7 @@
 package gwi.saturator
 
-object Dag {
+protected[saturator] object Dag {
+
   def root[V](edges: Set[(V,V)]): V = {
     val ancestorLessVertices = edges.flatMap(v => Set(v._1, v._2)) -- edges.map(_._2)
     require(ancestorLessVertices.size == 1, "DAG must be rooted !!!")

--- a/core/src/main/scala/gwi/saturator/DagFSM.scala
+++ b/core/src/main/scala/gwi/saturator/DagFSM.scala
@@ -71,7 +71,7 @@ object DagFSM {
   case class Saturate(dep: Set[Dependency]) extends Cmd
   case class SaturationResponse(dep: Dependency, succeeded: Boolean) extends Cmd
   case object ShutDown extends Cmd
-  private case class Initialize(partitionsByVertex: Map[DagVertex, Set[DagPartition]]) extends Cmd
+  protected[saturator] case class Initialize(partitionsByVertex: Map[DagVertex, Set[DagPartition]]) extends Cmd
 
   protected[saturator] case object DagEmpty extends FSMState { override def identifier: String = "Empty" }
   protected[saturator] case object Saturating extends FSMState { override def identifier: String = "Saturating" }

--- a/core/src/main/scala/gwi/saturator/DagFSM.scala
+++ b/core/src/main/scala/gwi/saturator/DagFSM.scala
@@ -8,13 +8,7 @@ import gwi.saturator.DagState.DagStateEvent
 
 import scala.math.Ordering
 import scala.reflect.ClassTag
-
-sealed trait Status extends FSMState
-object Status {
-  val Empty = "DagEmpty"
-  val DagSaturated = "DagSaturated"
-  val DagUnSaturated = "DagUnSaturated"
-}
+import DagFSM.Status
 
 class DagFSM(init: () => List[(DagVertex, List[DagPartition])], handler: ActorRef)(implicit edges: Set[(DagVertex, DagVertex)], po: Ordering[DagPartition], vo: Ordering[DagVertex])
   extends PersistentFSM[Status, DagState, DagStateEvent] with LoggingPersistentFSM[Status, DagState, DagStateEvent] with ActorLogging {
@@ -124,6 +118,13 @@ class DagFSM(init: () => List[(DagVertex, List[DagPartition])], handler: ActorRe
 }
 
 object DagFSM {
+  sealed trait Status extends FSMState
+  object Status {
+    val Empty = "DagEmpty"
+    val DagSaturated = "DagSaturated"
+    val DagUnSaturated = "DagUnSaturated"
+  }
+
   sealed trait Cmd
   case class CreatePartition(p: DagPartition) extends Cmd
   case class RemovePartitionVertex(p: DagPartition, v: DagVertex) extends Cmd

--- a/core/src/main/scala/gwi/saturator/DagFSM.scala
+++ b/core/src/main/scala/gwi/saturator/DagFSM.scala
@@ -1,113 +1,60 @@
 package gwi.saturator
 
-import akka.actor.Status.Failure
 import akka.actor.{ActorLogging, ActorRef, ActorRefFactory, Props}
 import akka.persistence.fsm.PersistentFSM.{FSMState, LogEntry}
 import akka.persistence.fsm.{LoggingPersistentFSM, PersistentFSM}
 import gwi.saturator.DagState.DagStateEvent
+import gwi.saturator.DagFSM._
 
 import scala.math.Ordering
 import scala.reflect.ClassTag
-import DagFSM.Status
 
 class DagFSM(init: () => List[(DagVertex, List[DagPartition])], handler: ActorRef)(implicit edges: Set[(DagVertex, DagVertex)], po: Ordering[DagPartition], vo: Ordering[DagVertex])
-  extends PersistentFSM[Status, DagState, DagStateEvent] with LoggingPersistentFSM[Status, DagState, DagStateEvent] with ActorLogging {
-  import DagFSM._
+  extends PersistentFSM[FSMState, DagState, DagStateEvent] with LoggingPersistentFSM[FSMState, DagState, DagStateEvent] with ActorLogging {
   import DagState._
 
   override def logDepth = 100
   override def persistenceId: String = self.path.name
   override def domainEventClassTag: ClassTag[DagStateEvent] = scala.reflect.classTag[DagStateEvent]
 
-  private var cmdQueue = Vector.empty[(Cmd, ActorRef)] // non-persistent user command queue, commands issued after ShutDown command would get refused
-
   startWith(DagEmpty, DagState.empty)
 
   when(DagEmpty) {
     case Event(Initialize(partitionsByVertex), _) =>
-      goto(DagUnSaturated) applying StateInitializedEvent(partitionsByVertex)
+      goto(Saturating) applying (StateInitializedEvent(partitionsByVertex), SaturationInitializedEvent)
   }
 
-  when(DagUnSaturated) {
-    case Event(Saturate(deps), _) =>
-      if (deps.isEmpty) {
-        log.info("No dependencies to saturate ...")
-        goto(DagSaturated)
-      } else {
-        stay() applying SaturationInitializedEvent(deps) andThen(_ => handler ! Saturate(deps) )
-      }
-    case Event(SaturationResponse(dep, succeeded), dagState) =>
-      val event = if (succeeded) SaturationSucceededEvent(dep) else SaturationFailedEvent(dep)
-      val newState = dagState.updated(event)(edges,po,vo)
-      lazy val newDeps = newState.getPendingToProgressPartitions(edges)
-      if (newState.isSaturated)
-        goto(DagSaturated) applying event
-      else if (newDeps.nonEmpty)
-        stay().applying(event, SaturationInitializedEvent(newDeps)) andThen (_ => handler ! Saturate(newDeps) )
-      else
-        stay() applying event
-    case Event(ShutDown, _) =>
-      log.info("Shutdown command received, waiting for state to become saturated ...")
-      cmdQueue :+= (ShutDown -> sender())
-      stay()
-    case Event(c@(_:CreatePartition | _:RemovePartitionVertex), _) =>
-      if (cmdQueue.lastOption.exists(_._1 == ShutDown)) {
-        sender() ! Failure(AlreadyShutdownException("Shutdown was scheduled, please try later !!!"))
-      } else {
-        log.warning(s"Stashing command $c, waiting for state to become saturated ...")
-        cmdQueue :+= (c.asInstanceOf[Cmd] -> sender())
-      }
-      stay()
-  }
+  when(Saturating) {
+    case Event(SaturationResponse(dep, succeeded), _) =>
+      goto(Saturating) applying(DagStateEvent.forSaturationOutcome(succeeded, dep), SaturationInitializedEvent)
 
-  when(DagSaturated) {
     case Event(c@CreatePartition(partition), _) =>
-      goto(DagUnSaturated) applying PartitionCreatedEvent(partition) andThen(dagState => sender() ! Cmd.Submitted(c, stateName, dagState, getLog) )
+      goto(Saturating) applying (PartitionCreatedEvent(partition), SaturationInitializedEvent) replying Cmd.Submitted(c, stateName, stateData, getLog)
+
     case Event(c@RemovePartitionVertex(partition, vertex), _) =>
-      goto(DagUnSaturated) applying PartitionVertexRemovedEvent(partition, vertex) andThen(dagState => sender() ! Cmd.Submitted(c, stateName, dagState, getLog) )
+      goto(Saturating) applying (PartitionVertexRemovedEvent(partition, vertex), SaturationInitializedEvent) replying  Cmd.Submitted(c, stateName, stateData, getLog)
+
     case Event(ShutDown, _) =>
       stop() replying Cmd.Submitted(ShutDown, stateName, stateData, getLog)
+  }
+
+  onTransition {
+    case DagEmpty -> DagEmpty if nextStateData.getVertexStatesByPartition.isEmpty => // Initialization happens only on fresh start, not when persistent event log is replayed
+      log.info("DAG created, initializing ...")
+      val initialData = init().map { case (v, p) => v -> p.toSet }.toMap
+      self ! Initialize(initialData)
+    case _ -> Saturating =>
+      val deps = nextStateData.getNewProgressingDeps
+      if (deps.nonEmpty) {
+        log.info(s"Saturating ${deps.size} dependencies ...")
+        handler ! Saturate(deps)
+      }
   }
 
   whenUnhandled {
     case Event(unknown, dagState) =>
       log.error(s"Unhandled command $unknown at status $stateName with state:\n $dagState")
       stay()
-  }
-
-  onTransition {
-    case DagEmpty -> DagEmpty if nextStateData.getVertexStatesByPartition.isEmpty =>
-      log.info("DAG created, initializing  ...")
-      val initialData = init().map { case (v, p) => v -> p.toSet }.toMap
-      self ! Initialize(initialData)
-    case DagSaturated -> DagUnSaturated =>
-      log.info("DAG unsaturated, getting dependencies to saturate ...")
-      val p2ps = nextStateData.getPendingToProgressPartitions(edges)
-      self ! Saturate(p2ps)
-    case DagEmpty -> DagUnSaturated =>
-      log.info("DAG is empty, getting dependencies to saturate ...")
-      val p2ps = nextStateData.getPendingToProgressPartitions(edges)
-      self ! Saturate(p2ps)
-    case DagUnSaturated -> DagSaturated =>
-      log.info("Dag Saturated ...")
-      cmdQueue.headOption.foreach { case (cmd, originalSender) =>
-        log.info("Enqueuing {}", cmd)
-        self.tell(cmd, originalSender)
-        cmdQueue = cmdQueue.tail
-      }
-  }
-
-  onTermination {
-    case StopEvent(reason, status, dagState) =>
-      cmdQueue.foreach { case (cmd, originalSender) => originalSender ! Cmd.Rejected(cmd, status, dagState, getLog) }
-      reason match {
-        case PersistentFSM.Failure(ex) =>
-          log.error(s"Failure due to $ex\n at status {} with state \n{}\n with events:\n{}", status, dagState, getLog.mkString("\n","\n","\n"))
-        case PersistentFSM.Shutdown =>
-          log.warning("Outside termination at status {} with state \n{}\n with events:\n{}", status, dagState, getLog.map(_.stateName).mkString("\n","\n","\n"))
-        case PersistentFSM.Normal =>
-          log.info("Stopping at status {} with state \n{}\n with events:\n{}", status, status, getLog.map(_.stateName).mkString("\n","\n","\n"))
-      }
   }
 
   def applyEvent(event: DagStateEvent, dagState: DagState): DagState = event match {
@@ -118,13 +65,6 @@ class DagFSM(init: () => List[(DagVertex, List[DagPartition])], handler: ActorRe
 }
 
 object DagFSM {
-  sealed trait Status extends FSMState
-  object Status {
-    val Empty = "DagEmpty"
-    val DagSaturated = "DagSaturated"
-    val DagUnSaturated = "DagUnSaturated"
-  }
-
   sealed trait Cmd
   case class CreatePartition(p: DagPartition) extends Cmd
   case class RemovePartitionVertex(p: DagPartition, v: DagVertex) extends Cmd
@@ -133,21 +73,15 @@ object DagFSM {
   case object ShutDown extends Cmd
   private case class Initialize(partitionsByVertex: Map[DagVertex, Set[DagPartition]]) extends Cmd
 
-  private case object DagEmpty extends Status { override def identifier: String = "DagEmpty" }
-  private case object DagSaturated extends Status { override def identifier: String = "DagSaturated" }
-  private case object DagUnSaturated extends Status { override def identifier: String = "DagUnSaturated" }
+  protected[saturator] case object DagEmpty extends FSMState { override def identifier: String = "Empty" }
+  protected[saturator] case object Saturating extends FSMState { override def identifier: String = "Saturating" }
 
   object Cmd {
-    case class Submitted(cmd: Cmd, status: Status, state: DagState, log: IndexedSeq[LogEntry[Status, DagState]])
-    case class Rejected(cmd: Cmd, status: Status, state: DagState, log: IndexedSeq[LogEntry[Status, DagState]])
+    case class Submitted(cmd: Cmd, status: FSMState, state: DagState, log: IndexedSeq[LogEntry[FSMState, DagState]])
   }
-
-  case class AlreadyShutdownException(msg: String) extends Exception(msg)
 
   def apply(init: => List[(DagVertex, List[DagPartition])], handler: ActorRef, name: String)
            (implicit arf: ActorRefFactory, edges: Set[(DagVertex, DagVertex)], po: Ordering[DagPartition], vo: Ordering[DagVertex]): ActorRef = {
     arf.actorOf(Props(classOf[DagFSM], init _, handler, edges, po, vo), name)
   }
 }
-
-

--- a/core/src/main/scala/gwi/saturator/DagModel.scala
+++ b/core/src/main/scala/gwi/saturator/DagModel.scala
@@ -11,7 +11,7 @@ trait DagVertex {
 }
 
 object DagVertex {
-  object State {
+  protected[saturator] object State {
     val Pending = "Pending"
     val Complete = "Complete"
     val InProgress = "InProgress"

--- a/core/src/test/scala/gwi/saturator/DagFSMSpec.scala
+++ b/core/src/test/scala/gwi/saturator/DagFSMSpec.scala
@@ -34,7 +34,7 @@ object DagFSMSpec {
 
 class DagFSMSpec(_system: ActorSystem) extends TestKit(_system) with DockerSupport with Matchers with FreeSpecLike with BeforeAndAfterAll with BeforeAndAfterEach with ImplicitSender {
   import DagMock._
-  val workTimeout = 10.seconds
+  private[this] val workTimeout = 10.seconds
 
   def this() = this(ActorSystem("DagFSMSpec", DagFSMSpec.config))
 

--- a/core/src/test/scala/gwi/saturator/DagSpec.scala
+++ b/core/src/test/scala/gwi/saturator/DagSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 class DagSpec extends FreeSpec with ScalaFutures with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
   import Dag._
 
-  val edges =
+  private[this] val edges =
     Set(
       1 -> 2,
       1 -> 3,

--- a/core/src/test/scala/gwi/saturator/DagStateSpec.scala
+++ b/core/src/test/scala/gwi/saturator/DagStateSpec.scala
@@ -10,7 +10,7 @@ import scala.language.implicitConversions
 class DagStateSpec extends FreeSpec with ScalaFutures with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
   import DagMock._
   import DagVertex.State._
-  implicit val edges: Set[(DagVertex, DagVertex)] =
+  private[this] implicit val edges: Set[(DagVertex, DagVertex)] =
     Set(
       1 -> 2,
       1 -> 3,


### PR DESCRIPTION
Current version has a flaw in FSM design, it uses these 2 states : Saturating,Saturated, where FSM at Saturating state queued saturation of further DAG layers until the current DAG layers are fully Saturated . It turned out to be wrong as if a certain branch of DAG takes client too long to saturate, saturation of all different DAG layers is thus postponed which is slowing the client down.

With this PR, saturation of layered DAG happens at the lowest granularity, which is a single dependency between DAG vertices, no matter which DAG layer they come from. Now if a certain vertex is unsaturated at 1000 layers, saturation of newly created layers happen immediately.