### PR TITLE
New partition check responsibility

### DIFF
--- a/api/src/main/scala/gwi.saturator/API.scala
+++ b/api/src/main/scala/gwi.saturator/API.scala
@@ -1,5 +1,6 @@
 package gwi.saturator
 
+import scala.collection.immutable.TreeSet
 import scala.math.Ordering
 
 trait DagPartition {
@@ -44,14 +45,17 @@ object SaturatorCmd {
   private[saturator] sealed trait Internal extends SaturatorCmd
 
   case class Saturate(dep: Set[Dependency]) extends Outgoing
+  case class GetPartitionChanges(rootVertex: DagVertex) extends Outgoing
   case object Saturated extends Outgoing
   case object Initialized extends Outgoing
   private[saturator] case class Initialize(partitionsByVertex: Map[DagVertex, Set[DagPartition]]) extends Internal
 
-  case class CreatePartition(p: DagPartition) extends Incoming
   case class RedoDagBranch(p: DagPartition, vertex: DagVertex) extends Incoming
   case class FixPartition(p: DagPartition) extends Incoming
   case class SaturationResponse(dep: Dependency, succeeded: Boolean) extends Incoming
   case object GetState extends Incoming
   case object ShutDown extends Incoming
+
+  case class PartitionInserts(partitions: TreeSet[DagPartition]) extends Incoming
+  case class PartitionUpdates(partitions: TreeSet[DagPartition]) extends Incoming
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-version in ThisBuild := "0.2.3"
+version in ThisBuild := "0.2.4"
 crossScalaVersions in ThisBuild := Seq("2.12.3", "2.11.8")
 organization in ThisBuild := "net.globalwebindex"
 fork in Test in ThisBuild := true

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-version in ThisBuild := "0.2.2"
+version in ThisBuild := "0.2.3"
 crossScalaVersions in ThisBuild := Seq("2.12.3", "2.11.8")
 organization in ThisBuild := "net.globalwebindex"
 fork in Test in ThisBuild := true

--- a/core/src/test/scala/gwi/saturator/DagStateSpec.scala
+++ b/core/src/test/scala/gwi/saturator/DagStateSpec.scala
@@ -140,7 +140,7 @@ class DagStateSpec extends FreeSpec with ScalaFutures with Matchers with BeforeA
     val initialState = (1 to 7).map(_ -> Complete).toMap
     val state = DagState(TreeMap((1L, initialState)), Set.empty)
     val expectedState: Map[DagVertex, String] = Map(1 -> Complete) ++ (2 to 7).map(_ -> Pending)
-    val actualState = state.updated(PartitionCreatedEvent(2L))
+    val actualState = state.updated(PartitionInsertsEvent(TreeSet(2L)))
     assertResult(expectedState)(actualState.getVertexStatesFor(2L))
     assert(!actualState.isSaturated)
   }

--- a/example/src/main/scala/gwi/saturator/Launcher.scala
+++ b/example/src/main/scala/gwi/saturator/Launcher.scala
@@ -44,8 +44,9 @@ class Example(edges: Set[(DagVertex,DagVertex)], init: => List[(DagVertex, List[
   private[this] val dagFSM = DagFSM(init, self, Some(PartitionChangesSchedule(interval, interval)), "example-dag-fsm")
 
   def receive: Receive = {
-    case GetPartitionChanges(_) =>
+    case Issued(GetPartitionChanges(_),_,_,_) =>
       dagFSM ! PartitionInserts(TreeSet(PartitionMock(partitionCounter.toString)))
+      log.info(s"New partition created ${partitionCounter.toString} ...")
       partitionCounter+=1
     case Issued(Saturate(deps), _, _, _) =>
       deps.foreach { dep =>


### PR DESCRIPTION
Relieving client application from having to schedule partition new/changed checks, it should be saturators responsibility.