### PR TITLE
single import library usage with in/out API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-version in ThisBuild := "0.3.1"
+version in ThisBuild := "0.3.2"
 crossScalaVersions in ThisBuild := Seq("2.12.3", "2.11.8")
 organization in ThisBuild := "net.globalwebindex"
 fork in Test in ThisBuild := true

--- a/core/src/main/scala/gwi/s8/DagState.scala
+++ b/core/src/main/scala/gwi/s8/DagState.scala
@@ -90,7 +90,7 @@ case class DagState private(vertexStatesByPartition: TreeMap[DagPartition, Map[D
   }
 
   def getRoot: DagVertex = dag.root
-  def getVertexStatesByPartition: Map[DagPartition, Map[DagVertex, String]] = vertexStatesByPartition
+  def getVertexStatesByPartition: TreeMap[DagPartition, Map[DagVertex, String]] = vertexStatesByPartition
   def isSaturated: Boolean = vertexStatesByPartition.values.forall { vertexStates =>
     vertexStates(dag.root) == Complete && dag.descendantsOfRoot(v => vertexStates(v) != Failed).forall(v => vertexStates(v) == Complete)
   }

--- a/example/src/main/scala/gwi/s8/Launcher.scala
+++ b/example/src/main/scala/gwi/s8/Launcher.scala
@@ -2,7 +2,6 @@ package gwi.s8
 
 import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
 import com.typesafe.config.ConfigFactory
-import gwi.s8.DagFSM.Issued
 import org.backuity.clist._
 import org.backuity.clist.util.Read
 
@@ -55,14 +54,14 @@ class Example(edges: Set[(DagVertex,DagVertex)], init: => List[(DagVertex, List[
   private[this] val dagFSM = DagFSM(init, self, schedule, "example-dag-fsm")
 
   def receive: Receive = {
-    case Issued(out.GetChangedPartitions(_),_,_,_) =>
+    case out.Issued(out.GetChangedPartitions(_),_,_) =>
       log.info(s"Partition changed ...")
       dagFSM ! in.InsertPartitions(TreeSet(DagPartition("1")))
-    case Issued(out.GetCreatedPartitions(_),_,_,_) =>
+    case out.Issued(out.GetCreatedPartitions(_),_,_) =>
       log.info(s"Partition created ${partitionCounter.toString} ...")
       dagFSM ! in.InsertPartitions(TreeSet(DagPartition(partitionCounter.toString)))
       partitionCounter+=1
-    case Issued(out.Saturate(dep), _, _, _) =>
+    case out.Issued(out.Saturate(dep),_,_) =>
       log.info("Saturating {}", dep)
       dagFSM ! in.AckSaturation(dep,true)
   }


### PR DESCRIPTION
It is a good quality metric of a library if users can use any publicly accessible part through a single access point. This is the convention used : 
```
import gwi.s8
s8.in.SomeIncomingMessage
s8.out.SomeOutgoingMessage
```

It makes it possible on the first sight to realize what is going In and Out... It is already implemented this way in https://github.com/GlobalWebIndex/mawex
